### PR TITLE
create clone data meal for admin

### DIFF
--- a/src/pages/admin/Ingredient/IngredientCreate.jsx
+++ b/src/pages/admin/Ingredient/IngredientCreate.jsx
@@ -11,10 +11,11 @@ import Grid from '@mui/material/Grid'
 import Modal from '@mui/material/Modal'
 import { createIngredientsAPI } from '~/apis'
 import { toast } from 'react-toastify'
-import { useNavigate } from 'react-router-dom'
-import { useState, useCallback } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom' // Thêm để lấy query params
+import { useState, useCallback, useEffect } from 'react'
 import Cropper from 'react-easy-crop'
 import getCroppedImg from '~/utils/getCroppedImg' // Tạo file utils để export ảnh đã crop
+import { getByIdIngredientsAPI } from '~/apis' // Giả sử có API này, nếu không có thì tạo
 
 const typeOptions = [
   { value: 'PROTEIN', label: 'Protein' },
@@ -24,6 +25,9 @@ const typeOptions = [
 ]
 
 const IngredientCreate = () => {
+  const [searchParams] = useSearchParams()
+  const cloneId = searchParams.get('clone') // Lấy ID từ query
+
   const { register, handleSubmit, control, formState: { errors }, setValue } = useForm({
     defaultValues: {
       title: '',
@@ -86,7 +90,7 @@ const IngredientCreate = () => {
       // Revoke imageSrc
       if (imageSrc) URL.revokeObjectURL(imageSrc)
       setImageSrc(null)
-    } catch (e) {
+    } catch {
       toast.error('Failed to crop image')
     }
   }
@@ -114,11 +118,46 @@ const IngredientCreate = () => {
     }
   }
 
+  useEffect(() => {
+    if (cloneId) {
+      // Fetch dữ liệu ingredient để clone
+      const fetchCloneData = async () => {
+        try {
+          const data = await getByIdIngredientsAPI(cloneId)
+          console.log('🚀 ~ fetchCloneData ~ data:', data)
+          // Set dữ liệu vào form
+          setValue('title', data.title || '')
+          setValue('description', data.description || '')
+          setValue('calories', data.calories || '')
+          setValue('protein', data.protein || '')
+          setValue('carbs', data.carbs || '')
+          setValue('fat', data.fat || '')
+          setValue('price', data.price || '')
+          setValue('stock', data.stock || '')
+          setValue('type', data.type || 'PROTEIN')
+          // Set image nếu có
+          if (data.image) {
+            setImagePreview(data.image)
+            // Nếu cần, tạo file từ URL để set vào form
+            // const response = await fetch(data.image)
+            // const blob = await response.blob()
+            // const file = new File([blob], 'cloned-image.jpg', { type: 'image/jpeg' })
+            // setValue('image', [file])
+          }
+          toast.info('Data cloned successfully! You can edit before creating.')
+        } catch (error) {
+          toast.error('Failed to clone data')
+        }
+      }
+      fetchCloneData()
+    }
+  }, [cloneId, setValue])
+
   return (
     <Box sx={{ maxWidth: 600, mx: 'auto', mt: 4, p: 2 }}>
       <Paper elevation={3} sx={{ p: { xs: 2, md: 4 }, borderRadius: 3 }}>
         <Typography variant="h4" mb={3} align="center" fontWeight={700}>
-          Create New Ingredient
+          {cloneId ? 'Clone Ingredient' : 'Create New Ingredient'} {/* Thay đổi title nếu clone */}
         </Typography>
         <form onSubmit={handleSubmit(onSubmit)} autoComplete="off">
           <Grid container spacing={2}>

--- a/src/pages/admin/Ingredient/IngredientList.jsx
+++ b/src/pages/admin/Ingredient/IngredientList.jsx
@@ -9,6 +9,7 @@ import DeleteIcon from '@mui/icons-material/DeleteOutlined'
 import RemoveRedEyeIcon from '@mui/icons-material/RemoveRedEye'
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz'
 import EditIcon from '@mui/icons-material/Edit'
+import ContentCopyIcon from '@mui/icons-material/ContentCopy' // Thêm icon clone
 import Menu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
 import Dialog from '@mui/material/Dialog'
@@ -70,6 +71,13 @@ const IngredientList = () => {
   const handleEditClick = () => {
     if (selectedRow) {
       navigate(`/management/ingredients/edit/${selectedRow.id}`)
+      handleCloseMenu()
+    }
+  }
+
+  const handleCloneClick = () => {
+    if (selectedRow) {
+      navigate(`/management/ingredients/create?clone=${selectedRow.id}`)
       handleCloseMenu()
     }
   }
@@ -211,6 +219,10 @@ const IngredientList = () => {
         <MenuItem onClick={handleEditClick}>
           <EditIcon fontSize="small" sx={{ mr: 1, color: 'primary.main' }} />
           Edit
+        </MenuItem>
+        <MenuItem onClick={handleCloneClick}> {/* Thêm menu item Clone */}
+          <ContentCopyIcon fontSize="small" sx={{ mr: 1, color: 'info.main' }} />
+          Clone
         </MenuItem>
         <MenuItem onClick={handleAskDelete}>
           <DeleteIcon fontSize="small" sx={{ mr: 1, color: 'error.main' }} />

--- a/src/pages/admin/MenuMeal/MenuMealList.jsx
+++ b/src/pages/admin/MenuMeal/MenuMealList.jsx
@@ -9,6 +9,7 @@ import DeleteIcon from '@mui/icons-material/DeleteOutlined'
 import RemoveRedEyeIcon from '@mui/icons-material/RemoveRedEye'
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz'
 import EditIcon from '@mui/icons-material/Edit'
+import ContentCopyIcon from '@mui/icons-material/ContentCopy' // Thêm icon clone
 import Menu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
 import Dialog from '@mui/material/Dialog'
@@ -63,6 +64,13 @@ const MenuMealList = () => {
   const handleEditClick = () => {
     if (selectedRow) {
       navigate(`/management/menu-meals/edit/${selectedRow.slug}`)
+      handleCloseMenu()
+    }
+  }
+
+  const handleCloneClick = () => {
+    if (selectedRow) {
+      navigate(`/management/menu-meals/create?clone=${selectedRow.slug}`)
       handleCloseMenu()
     }
   }
@@ -204,6 +212,10 @@ const MenuMealList = () => {
         <MenuItem onClick={handleEditClick}>
           <EditIcon fontSize="small" sx={{ mr: 1, color: 'primary.main' }} />
           Edit
+        </MenuItem>
+        <MenuItem onClick={handleCloneClick}> {/* Thêm menu item Clone */}
+          <ContentCopyIcon fontSize="small" sx={{ mr: 1, color: 'info.main' }} />
+          Clone
         </MenuItem>
         <MenuItem onClick={handleAskDelete}>
           <DeleteIcon fontSize="small" sx={{ mr: 1, color: 'error.main' }} />

--- a/src/pages/admin/WeekMeal/WeekMealList.jsx
+++ b/src/pages/admin/WeekMeal/WeekMealList.jsx
@@ -22,6 +22,7 @@ import moment from 'moment'
 import { getWeekMealPlanAPI } from '~/apis'
 import { useNavigate } from 'react-router-dom'
 import { toast } from 'react-toastify'
+import ContentCopyIcon from '@mui/icons-material/ContentCopy' // Thêm icon clone
 
 
 const mealTypes = [
@@ -79,6 +80,17 @@ const WeekMealList = () => {
           >
             Create New Week Meal
           </Button>
+          {weekData && (
+            <Button
+              variant="outlined"
+              color="info"
+              startIcon={<ContentCopyIcon />}
+              onClick={() => navigate(`/management/week-meals/create?clone=${weekData.id}`)}
+              sx={{ fontWeight: 'bold' }}
+            >
+              Clone This Week Meal
+            </Button>
+          )}
         </Box>
 
         {/* Select meal type */}


### PR DESCRIPTION
This pull request introduces a "Clone" feature for Ingredients, Menu Meals, and Week Meals in the admin panel. Users can now quickly create new entries by cloning existing ones, which pre-fills the creation form with data from the selected item. This streamlines the process for creating similar items and improves admin efficiency. The changes touch both the UI (adding "Clone" buttons and menu items) and the logic (fetching and applying the cloned data).

**Ingredient Cloning:**
- Added a "Clone" option to the ingredient list menu, which navigates to the creation form with a `clone` query parameter. The form fetches the ingredient data by ID and pre-fills the fields, including image preview. [[1]](diffhunk://#diff-8d26be83ff63a726f69d7297b4e5e82d6db7952c6d558ea8529c15a86a956768R12) [[2]](diffhunk://#diff-8d26be83ff63a726f69d7297b4e5e82d6db7952c6d558ea8529c15a86a956768R78-R84) [[3]](diffhunk://#diff-8d26be83ff63a726f69d7297b4e5e82d6db7952c6d558ea8529c15a86a956768R223-R226) [[4]](diffhunk://#diff-6a2c4e2e8df52e98f095ead1f3e2a00c9fe6d995211dca099076aa0dc866d148L14-R18) [[5]](diffhunk://#diff-6a2c4e2e8df52e98f095ead1f3e2a00c9fe6d995211dca099076aa0dc866d148R28-R30) [[6]](diffhunk://#diff-6a2c4e2e8df52e98f095ead1f3e2a00c9fe6d995211dca099076aa0dc866d148R121-R160)
- The form title dynamically changes to "Clone Ingredient" when cloning.

**Menu Meal Cloning:**
- Added a "Clone" menu item to the menu meal list, navigating to the creation page with a `clone` query parameter (using the meal's slug). The creation form fetches and pre-fills data, including image preview. [[1]](diffhunk://#diff-361f6815b3619bdb80313f44a63f106c474208d78cfa7aa8ad7809d393b740f7R12) [[2]](diffhunk://#diff-361f6815b3619bdb80313f44a63f106c474208d78cfa7aa8ad7809d393b740f7R71-R77) [[3]](diffhunk://#diff-361f6815b3619bdb80313f44a63f106c474208d78cfa7aa8ad7809d393b740f7R216-R219) [[4]](diffhunk://#diff-9f016d98c368446a7284e123f16e2f8f09c2a3861bee873afe1c890d480d990dL12-R15) [[5]](diffhunk://#diff-9f016d98c368446a7284e123f16e2f8f09c2a3861bee873afe1c890d480d990dR27-R29) [[6]](diffhunk://#diff-9f016d98c368446a7284e123f16e2f8f09c2a3861bee873afe1c890d480d990dR120-R158)
- The form title updates to "Clone Meal" when cloning.

**Week Meal Cloning:**
- Added a "Clone This Week Meal" button on the week meal list page, which navigates to the creation page with a `clone` query parameter. The creation form fetches the week meal data by ID and pre-fills the type, start date, and daily meals. [[1]](diffhunk://#diff-82b5bdbae5a8c6370e66f25d02b213a5910b1ddeb848ed056b3350c245eba42bR25) [[2]](diffhunk://#diff-82b5bdbae5a8c6370e66f25d02b213a5910b1ddeb848ed056b3350c245eba42bR83-R93) [[3]](diffhunk://#diff-b7f2d7c9523dcff354efcc3d8928851380e48c56c9eb49146437de94944fa0f2L2-R2) [[4]](diffhunk://#diff-b7f2d7c9523dcff354efcc3d8928851380e48c56c9eb49146437de94944fa0f2L26-R26) [[5]](diffhunk://#diff-b7f2d7c9523dcff354efcc3d8928851380e48c56c9eb49146437de94944fa0f2R47-L48) [[6]](diffhunk://#diff-b7f2d7c9523dcff354efcc3d8928851380e48c56c9eb49146437de94944fa0f2R91-R118)
- The form title changes to "Clone WeekMeal" when cloning.

**General Improvements:**
- All clone forms provide user feedback via toasts for successful or failed data cloning. [[1]](diffhunk://#diff-6a2c4e2e8df52e98f095ead1f3e2a00c9fe6d995211dca099076aa0dc866d148R121-R160) [[2]](diffhunk://#diff-9f016d98c368446a7284e123f16e2f8f09c2a3861bee873afe1c890d480d990dR120-R158) [[3]](diffhunk://#diff-b7f2d7c9523dcff354efcc3d8928851380e48c56c9eb49146437de94944fa0f2R91-R118)
- Minor code cleanup, such as improved error handling in image cropping.