### PR TITLE
fix data dashboard

### DIFF
--- a/src/pages/admin/Dashboard/Dashboard.jsx
+++ b/src/pages/admin/Dashboard/Dashboard.jsx
@@ -13,7 +13,7 @@ const customBlue = '#2196F3'
 
 export default function Dashboard() {
   return (
-    <Box sx={{ bgcolor: '#f8f7fa', p: 3, minHeight: '100vh' }}>
+    <Box sx={{ p: 3, minHeight: '100vh' }}>
       {/* Overview */}
       <Paper elevation={3} sx={{ borderRadius: 3, p: 2, mb: 2 }}>
         <OverviewDashboard customBlue={customBlue} />


### PR DESCRIPTION
This pull request makes a minor visual update to the `Dashboard` component by removing the background color from the main container. This change will result in the dashboard using the default background color instead of the previously set light gray.

- UI update:
  * Removed the `bgcolor: '#f8f7fa'` style from the main `Box` container in `Dashboard.jsx`, resulting in the default background color being used.